### PR TITLE
Added an if-def around method calls that were specific a sub spec

### DIFF
--- a/ErrorKit/Core/MRErrorFormatter.m
+++ b/ErrorKit/Core/MRErrorFormatter.m
@@ -134,11 +134,14 @@
 {
     if ([domain isEqualToString:NSCocoaErrorDomain]) {
         return [MRErrorFormatter debugStringWithCocoaCode:code];
-    } else if ([domain isEqualToString:NSURLErrorDomain]) {
-        return [MRErrorFormatter debugStringWithURLCode:code];
     } else if ([domain isEqualToString:NSXMLParserErrorDomain]) {
         return [MRErrorFormatter debugStringWithXMLParserCode:code];
     }
+#ifdef ERROR_KIT_HTTP
+    else if ([domain isEqualToString:NSURLErrorDomain]) {
+      return [MRErrorFormatter debugStringWithURLCode:code];
+    }
+#endif
 #ifdef ERROR_KIT_ACCOUNTS
     else if ([domain isEqualToString:ACErrorDomain]) {
         return [MRErrorFormatter debugStringWithAccountsCode:code];
@@ -211,11 +214,14 @@
 {
     if ([domain isEqualToString:NSCocoaErrorDomain]) {
         return [MRErrorFormatter stringWithCocoaCode:code];
-    } else if ([domain isEqualToString:NSURLErrorDomain]) {
-        return [MRErrorFormatter stringWithURLCode:code];
     } else if ([domain isEqualToString:NSXMLParserErrorDomain]) {
         return [MRErrorFormatter stringWithXMLParserCode:code];
     }
+#ifdef ERROR_KIT_HTTP
+    else if ([domain isEqualToString:NSURLErrorDomain]) {
+      return [MRErrorFormatter stringWithURLCode:code];
+    }
+#endif
 #ifdef ERROR_KIT_ACCOUNTS
     else if ([domain isEqualToString:ACErrorDomain]) {
         return [MRErrorFormatter stringWithAccountsCode:code];


### PR DESCRIPTION
Just a small change that fixes an error which arose when a project only has a dependency on `ErrorKit/Core`. The existing code called methods specific to categories defined in `ErrorKit/HTTP`, these have now been wrapped in `ifdef`s so they'll only be applicable when the subspec is used.
